### PR TITLE
Simpler splitting using append_indicator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,10 +34,10 @@ Quick start
 .. sourcecode:: python
 
    >>> import msgsplitter
-   >>> result = msgsplitter.split("Hello, this is a really long message.", length_limit=30)
+   >>> result = msgsplitter.split('Hello, this is a really long message.', length_limit=30)
    >>> result
    ['Hello, this is a really (1/2)', 'long message. (2/2)']
-   >> result = print(split('Hello, this is a really long message.', length_limit=30, append_indicator=False))
+   >> result = msgsplitter.split('Hello, this is a really long message.', length_limit=30, append_indicator=False)
    >> result
    ['Hello, this is a really long', 'message.']
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,9 @@ Quick start
    >>> result = msgsplitter.split("Hello, this is a really long message.", length_limit=30)
    >>> result
    ['Hello, this is a really (1/2)', 'long message. (2/2)']
+   >> result = print(split('Hello, this is a really long message.', length_limit=30, append_indicator=False))
+   >> result
+   ['Hello, this is a really long', 'message.']
 
 Run tests
 -----------

--- a/msgsplitter/split.py
+++ b/msgsplitter/split.py
@@ -14,7 +14,16 @@ def _get_split_messages(message, formatter):
 
 
 def split(message: str, length_limit: int,
-          formatter_cls: Callable[[int], FormatterBase] = IndicatorFormatter):
+          formatter_cls: Callable[[int], FormatterBase] = None, append_indicator: bool = True):
+    """
+    Uses formatter_cls if exists, otherwise chooses formatter by append_indicator
+    """
+    if formatter_cls is None:
+        if append_indicator:
+            formatter_cls = IndicatorFormatter
+        else:
+            formatter_cls = FormatterBase
+
     formatter = formatter_cls(length_limit)
     split_messages, formatter = _get_split_messages(message, formatter)
     return formatter.format(split_messages)
@@ -22,3 +31,4 @@ def split(message: str, length_limit: int,
 
 if __name__ == '__main__':
     print(split('Hello, this is a really long message.', length_limit=30))
+    print(split('Hello, this is a really long message.', length_limit=30, append_indicator=False))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setuptools.setup(
     name='msgsplitter',
-    version='1.0.1',
+    version='1.1.0',
     author="Elijas Dapšauskas",
     author_email="master.elijas@gmail.com",
     description="Split messages (strings) to fit an arbitrary character limit",


### PR DESCRIPTION
You can now use

    print(split('Hello, this is a really long message.', length_limit=30, append_indicator=False))

instead of using additional classes. Does **not** break previous behaviour.

